### PR TITLE
Add find by all tags feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindTagsAndCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTagsAndCommand.java
@@ -1,0 +1,58 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.tag.TagsAndFoundPredicate;
+
+/**
+ * Finds and lists all persons in address book who contains all the tags in the argument.
+ * Tag matching is case sensitive.
+ */
+public class FindTagsAndCommand extends Command {
+
+    public static final String COMMAND_WORD = "findTagsAnd";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons who contains all of the tags "
+            + "and displays them as a list with index numbers.\n"
+            + "Parameters: TAG [MORE_TAGS]...\n"
+            + "Example: " + COMMAND_WORD + " car health death";
+
+    private final TagsAndFoundPredicate predicate;
+
+    public FindTagsAndCommand(TagsAndFoundPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof FindTagsAndCommand)) {
+            return false;
+        }
+
+        FindTagsAndCommand otherFindTagsAndCommand = (FindTagsAndCommand) other;
+        return predicate.equals(otherFindTagsAndCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindTagsAndCommand;
 import seedu.address.logic.commands.FindTagsOrCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.LastContactCommand;
@@ -76,6 +77,9 @@ public class AddressBookParser {
 
         case FindTagsOrCommand.COMMAND_WORD:
             return new FindTagsOrCommandParser().parse(arguments);
+
+        case FindTagsAndCommand.COMMAND_WORD:
+            return new FindTagsAndCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/FindTagsAndCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindTagsAndCommandParser.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import seedu.address.logic.commands.FindTagsAndCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagsAndFoundPredicate;
+
+/**
+ * Parses input arguments and creates a new FindTagsOrCommand object
+ */
+public class FindTagsAndCommandParser implements Parser<FindTagsAndCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FindTagsOrCommand
+     * and returns a FindTagsOrCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public FindTagsAndCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTagsAndCommand.MESSAGE_USAGE));
+        }
+
+        String[] tags = trimmedArgs.split("\\s+");
+        Set<Tag> tagSet = ParserUtil.parseTags(Arrays.asList(tags));
+
+        return new FindTagsAndCommand(new TagsAndFoundPredicate(tagSet));
+    }
+
+}

--- a/src/main/java/seedu/address/model/tag/TagsAndFoundPredicate.java
+++ b/src/main/java/seedu/address/model/tag/TagsAndFoundPredicate.java
@@ -1,0 +1,44 @@
+package seedu.address.model.tag;
+
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+/**
+ * Tests that a {@code Person}'s {@code Tag} matches all the tags given.
+ */
+public class TagsAndFoundPredicate implements Predicate<Person> {
+
+    private final Set<Tag> tags;
+
+    public TagsAndFoundPredicate(Set<Tag> tags) {
+        this.tags = tags;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getTags().containsAll(tags);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof TagsAndFoundPredicate)) {
+            return false;
+        }
+
+        TagsAndFoundPredicate otherTagsAndFoundPredicate = (TagsAndFoundPredicate) other;
+        return tags.equals(otherTagsAndFoundPredicate.tags);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("tags", tags).toString();
+    }
+
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -29,7 +29,7 @@
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
-    "tags" : [ "covid" ],
+    "tags" : [ "covid", "flight", "disability" ],
     "upcoming": "12-12-2024 1200",
     "lastcontact": "13-03-2024 0600"
   }, {

--- a/src/test/java/seedu/address/logic/commands/FindTagsAndCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTagsAndCommandTest.java
@@ -1,0 +1,115 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalPersons.getTypicalPersons;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.tag.TagsAndFoundPredicate;
+import seedu.address.testutil.TagBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindTagsOrCommand}.
+ */
+public class FindTagsAndCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+
+    @Test
+    public void equals() {
+        TagsAndFoundPredicate firstPredicate = preparePredicate("first");
+        TagsAndFoundPredicate secondPredicate = preparePredicate("second");
+
+        FindTagsAndCommand firstCommand = new FindTagsAndCommand(firstPredicate);
+        FindTagsAndCommand secondCommand = new FindTagsAndCommand(secondPredicate);
+
+        assertTrue(firstCommand.equals(firstCommand));
+        FindTagsAndCommand firstCommandCopy = new FindTagsAndCommand(firstPredicate);
+        assertTrue(firstCommand.equals(firstCommandCopy));
+        assertFalse(firstCommand.equals(1));
+        assertFalse(firstCommand.equals(null));
+        assertFalse(firstCommand.equals(secondCommand));
+    }
+
+    @Test
+    public void execute_zeroTags_allPersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, getTypicalPersons().size());
+        TagsAndFoundPredicate predicate = preparePredicate(" ");
+        FindTagsAndCommand command = new FindTagsAndCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(getTypicalPersons(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_oneTag_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        TagsAndFoundPredicate predicate = preparePredicate("car");
+        FindTagsAndCommand command = new FindTagsAndCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(List.of(ALICE, BENSON), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_oneTagWrongCase_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        TagsAndFoundPredicate predicate = preparePredicate("Car");
+        FindTagsAndCommand command = new FindTagsAndCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(List.of(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTags_onePersonWithAllTagsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        TagsAndFoundPredicate predicate = preparePredicate("car death");
+        FindTagsAndCommand command = new FindTagsAndCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(List.of(BENSON), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTags_onePersonWithNotAllTagsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1);
+        TagsAndFoundPredicate predicate = preparePredicate("flight covid");
+        FindTagsAndCommand command = new FindTagsAndCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(List.of(DANIEL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void toStringMethod() {
+        TagsAndFoundPredicate predicate = preparePredicate("tag");
+        FindTagsAndCommand command = new FindTagsAndCommand(predicate);
+        String expected = FindTagsAndCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, command.toString());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TagsAndFoundPredicate}.
+     */
+    private TagsAndFoundPredicate preparePredicate(String userInput) {
+        List<String> tagList = List.of(userInput.split("\\s+"));
+        return new TagsAndFoundPredicate(TagBuilder.build(tagList));
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -20,6 +20,7 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindTagsAndCommand;
 import seedu.address.logic.commands.FindTagsOrCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.LastContactCommand;
@@ -29,6 +30,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.LastContact;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.TagsAndFoundPredicate;
 import seedu.address.model.tag.TagsOrFoundPredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
@@ -95,6 +97,14 @@ public class AddressBookParserTest {
         FindTagsOrCommand command = (FindTagsOrCommand) parser.parseCommand(
                 FindTagsOrCommand.COMMAND_WORD + " " + String.join(" ", tags));
         assertEquals(new FindTagsOrCommand(new TagsOrFoundPredicate(TagBuilder.build(tags))), command);
+    }
+
+    @Test
+    public void parseCommand_findTagsAnd() throws Exception {
+        List<String> tags = List.of("foo", "bar", "baz");
+        FindTagsAndCommand command = (FindTagsAndCommand) parser.parseCommand(
+                FindTagsAndCommand.COMMAND_WORD + " " + String.join(" ", tags));
+        assertEquals(new FindTagsAndCommand(new TagsAndFoundPredicate(TagBuilder.build(tags))), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindTagsAndCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindTagsAndCommandParserTest.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindTagsAndCommand;
+import seedu.address.model.tag.Tag;
+import seedu.address.model.tag.TagsAndFoundPredicate;
+import seedu.address.testutil.TagBuilder;
+
+public class FindTagsAndCommandParserTest {
+
+    private FindTagsAndCommandParser parser = new FindTagsAndCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindTagsAndCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "!#@#$", Tag.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindTagsOrCommand() {
+        List<String> tagList = List.of("car", "health");
+        FindTagsAndCommand expectedCommand =
+                new FindTagsAndCommand(new TagsAndFoundPredicate(TagBuilder.build(tagList)));
+        assertParseSuccess(parser, "car health", expectedCommand);
+
+        assertParseSuccess(parser, " \n car \n \t health  \t", expectedCommand);
+    }
+
+}

--- a/src/test/java/seedu/address/model/tag/TagsAndFoundPredicateTest.java
+++ b/src/test/java/seedu/address/model/tag/TagsAndFoundPredicateTest.java
@@ -1,0 +1,78 @@
+package seedu.address.model.tag;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TagBuilder;
+
+
+public class TagsAndFoundPredicateTest {
+
+    @Test
+    public void equals() {
+        List<String> firstTagList = List.of("first");
+        List<String> secondTagList = List.of("first", "second");
+
+        TagsAndFoundPredicate firstPredicate = preparePredicate(firstTagList);
+        TagsAndFoundPredicate secondPredicate = preparePredicate(secondTagList);
+
+        assertTrue(firstPredicate.equals(firstPredicate));
+        TagsAndFoundPredicate firstPredicateCopy = preparePredicate(firstTagList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+        assertFalse(firstPredicate.equals(1));
+        assertFalse(firstPredicate.equals(null));
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_tagFound_returnsTrue() {
+        TagsAndFoundPredicate predicate = preparePredicate(List.of("car"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("car").build()));
+
+        predicate = preparePredicate(List.of("car", "health"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("car", "health").build()));
+
+        predicate = preparePredicate(List.of("car", "health"));
+        assertTrue(predicate.test(new PersonBuilder().withTags("car", "health", "flight").build()));
+
+        predicate = preparePredicate(List.of());
+        assertTrue(predicate.test(new PersonBuilder().withTags("car").build()));
+    }
+
+    @Test
+    public void test_tagNotFound_returnsFalse() {
+        TagsAndFoundPredicate predicate = preparePredicate(List.of("motorcycle"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("car", "health").build()));
+
+        predicate = preparePredicate(List.of("Car", "Health"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("car", "health").build()));
+
+        predicate = preparePredicate(List.of("car", "health"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("health").build()));
+
+        predicate = preparePredicate(List.of("car", "health"));
+        assertFalse(predicate.test(new PersonBuilder().withTags("car", "covid").build()));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> tagList = List.of("tag1", "tag2");
+        TagsAndFoundPredicate predicate = preparePredicate(tagList);
+        String expected = TagsAndFoundPredicate.class.getCanonicalName() + "{tags=" + TagBuilder.build(tagList) + "}";
+        assertEquals(expected, predicate.toString());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TagsAndFoundPredicate}.
+     */
+    private TagsAndFoundPredicate preparePredicate(List<String> tagList) {
+        return new TagsAndFoundPredicate(TagBuilder.build(tagList));
+    }
+
+}

--- a/src/test/java/seedu/address/model/tag/TagsOrFoundPredicateTest.java
+++ b/src/test/java/seedu/address/model/tag/TagsOrFoundPredicateTest.java
@@ -35,15 +35,12 @@ public class TagsOrFoundPredicateTest {
         TagsOrFoundPredicate predicate = preparePredicate(List.of("car"));
         assertTrue(predicate.test(new PersonBuilder().withTags("car").build()));
 
-        // Multiple keywords
         predicate = preparePredicate(List.of("car", "health"));
         assertTrue(predicate.test(new PersonBuilder().withTags("health").build()));
 
-        // Only one matching keyword
         predicate = preparePredicate(List.of("car", "health"));
         assertTrue(predicate.test(new PersonBuilder().withTags("car", "covid").build()));
 
-        // Mixed-case keywords
         predicate = preparePredicate(List.of("car", "health"));
         assertTrue(predicate.test(new PersonBuilder().withTags("car", "health").build()));
     }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -39,7 +39,8 @@ public class TypicalPersons {
             .withEmail("heinz@example.com").withAddress("wall street").withTags("health")
             .withUpcoming("05-05-2024 1234").withTags("health").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("covid").build();
+            .withEmail("cornelia@example.com").withAddress("10th street")
+            .withTags("covid", "flight", "disability").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")


### PR DESCRIPTION
This feature returns all people that contain tags that match all tags inputted by user. The person must contain all the tags defined for the predicate to return true. This is akin to the AND boolean as the person must contain all tags.