### PR TITLE
Update edit command to edit lastcontact field

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -48,7 +48,7 @@ public class Messages {
         builder.append("; Upcoming: ")
                 .append(person.getUpcoming());
         builder.append("; Last contacted: ")
-                .append(person.getLastcontact().getDateTimeString())
+                .append(person.getLastcontact().toString())
                 .append(";");
         return builder.toString();
     }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LASTCONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -47,7 +48,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG] "
-            + "[" + PREFIX_UPCOMING + "UPCOMING]...\n"
+            + "[" + PREFIX_UPCOMING + "UPCOMING] "
+            + "[" + PREFIX_LASTCONTACT + "LASTCONTACT]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -105,7 +107,7 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         Upcoming updatedUpcoming = editPersonDescriptor.getUpcoming().orElse(personToEdit.getUpcoming());
-        LastContact updatedLastContact = personToEdit.getLastcontact(); // Edit command does not allow editing remarks
+        LastContact updatedLastContact = editPersonDescriptor.getLastcontact().orElse(personToEdit.getLastcontact());
 
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedUpcoming,
                 updatedLastContact);
@@ -169,7 +171,7 @@ public class EditCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags, upcoming);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags, upcoming, lastContact);
         }
 
         public void setName(Name name) {
@@ -204,10 +206,6 @@ public class EditCommand extends Command {
             return Optional.ofNullable(address);
         }
 
-        public void setLastContact(LastContact lastContact) {
-            this.lastContact = lastContact;
-        }
-
         /**
          * Sets {@code tags} to this object's {@code tags}.
          * A defensive copy of {@code tags} is used internally.
@@ -234,6 +232,13 @@ public class EditCommand extends Command {
             return Optional.ofNullable(upcoming);
         }
 
+        public void setLastContact(LastContact lastContact) {
+            this.lastContact = lastContact;
+        }
+
+        public Optional<LastContact> getLastcontact() {
+            return Optional.ofNullable(lastContact);
+        }
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -251,7 +256,8 @@ public class EditCommand extends Command {
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags)
-                    && Objects.equals(upcoming, otherEditPersonDescriptor.upcoming);
+                    && Objects.equals(upcoming, otherEditPersonDescriptor.upcoming)
+                    && Objects.equals(lastContact, otherEditPersonDescriptor.lastContact);
         }
 
         @Override
@@ -263,7 +269,9 @@ public class EditCommand extends Command {
                     .add("address", address)
                     .add("tags", tags)
                     .add("upcoming", upcoming)
+                    .add("lastcontact", lastContact)
                     .toString();
         }
+
     }
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_LASTCONTACT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
@@ -34,7 +35,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
-                PREFIX_TAG, PREFIX_UPCOMING);
+                PREFIX_TAG, PREFIX_UPCOMING, PREFIX_LASTCONTACT);
 
         Index index;
 
@@ -45,7 +46,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-            PREFIX_ADDRESS, PREFIX_UPCOMING);
+            PREFIX_ADDRESS, PREFIX_UPCOMING, PREFIX_LASTCONTACT);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 
@@ -65,7 +66,10 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (argMultimap.getValue(PREFIX_UPCOMING).isPresent()) {
             editPersonDescriptor.setUpcoming(ParserUtil.parseUpcoming(argMultimap.getValue(PREFIX_UPCOMING).get()));
         }
-
+        if (argMultimap.getValue(PREFIX_LASTCONTACT).isPresent()) {
+            editPersonDescriptor.setLastContact(ParserUtil.parseLastContact(argMultimap
+                    .getValue(PREFIX_LASTCONTACT).get()));
+        }
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
         }

--- a/src/main/java/seedu/address/model/person/LastContact.java
+++ b/src/main/java/seedu/address/model/person/LastContact.java
@@ -46,7 +46,8 @@ public class LastContact {
         }
     }
 
-    public String getDateTimeString() {
+    @Override
+    public String toString() {
         return this.dateTime;
     }
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -65,7 +65,7 @@ class JsonAdaptedPerson {
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
         upcoming = source.getUpcoming().toString();
-        lastcontact = source.getLastcontact().getDateTimeString();
+        lastcontact = source.getLastcontact().toString();
     }
 
     /**

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -60,6 +60,6 @@ public class PersonCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         upcoming.setText(person.getUpcoming().toString());
-        lastcontact.setText("Last contacted: " + person.getLastcontact().getDateTimeString());
+        lastcontact.setText("Last contacted: " + person.getLastcontact().toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -41,7 +41,9 @@ public class CommandTestUtil {
     public static final String VALID_UPCOMING_AMY = "12-12-2024 1200";
     public static final String VALID_UPCOMING_BOB = "05-05-2024 1700";
     public static final String VALID_LAST_CONTACT = "13-03-2024 0600";
-    public static final String VALID_LAST_CONTACT_BOB = "13-04-2024 1600";
+    public static final String VALID_LAST_CONTACT_AMY = "13-04-2024 1600";
+    public static final String VALID_LAST_CONTACT_BOB = "13-04-2024 1700";
+
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -62,9 +64,6 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
-    public static final String INVALID_UPCOMING_DESC = " " + PREFIX_UPCOMING + "12-12-2024"; // invalid date format
-    public static final String INVALID_LAST_CONTACT = " " + PREFIX_LASTCONTACT + "13-03-20242 0600"; // additional digit
-
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 
@@ -74,10 +73,12 @@ public class CommandTestUtil {
     static {
         DESC_AMY = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_AMY).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_FRIEND).withUpcoming(VALID_UPCOMING_AMY).build();
+                .withTags(VALID_TAG_FRIEND).withUpcoming(VALID_UPCOMING_AMY).withLastContact(VALID_LAST_CONTACT_AMY)
+                .build();
         DESC_BOB = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withUpcoming(VALID_UPCOMING_BOB).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withUpcoming(VALID_UPCOMING_BOB)
+                .withLastContact(VALID_LAST_CONTACT_BOB).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LAST_CONTACT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LAST_CONTACT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
@@ -156,7 +158,9 @@ public class EditCommandTest {
         EditPersonDescriptor copyDescriptor = new EditPersonDescriptor(DESC_AMY);
         EditCommand commandWithSameValues = new EditCommand(INDEX_FIRST_PERSON, copyDescriptor);
         EditPersonDescriptor editedDescriptor = new EditPersonDescriptorBuilder(DESC_AMY)
-            .withUpcoming(VALID_UPCOMING_BOB).build();
+                .withUpcoming(VALID_UPCOMING_BOB).build();
+        EditPersonDescriptor editedDescriptor_lastcontact = new EditPersonDescriptorBuilder(DESC_AMY)
+                .withLastContact(VALID_LAST_CONTACT_BOB).build();
 
         assertTrue(standardCommand.equals(commandWithSameValues));
 
@@ -187,6 +191,20 @@ public class EditCommandTest {
         editedDescriptor = new EditPersonDescriptorBuilder(DESC_BOB)
                 .withUpcoming(VALID_UPCOMING_AMY).build();
         assertFalse(DESC_AMY.equals(editedDescriptor));
+
+        // different lastcontact -> return false
+        assertFalse(DESC_AMY.equals(editedDescriptor_lastcontact));
+
+        // different lastcontact, same other fields -> return false
+        editedDescriptor_lastcontact = new EditPersonDescriptorBuilder(DESC_AMY)
+                .withLastContact(VALID_LAST_CONTACT_BOB).build();
+        assertFalse(DESC_AMY.equals(editedDescriptor_lastcontact));
+
+        // same lastcontact -> return true
+        editedDescriptor_lastcontact = new EditPersonDescriptorBuilder(DESC_AMY)
+                .withLastContact(VALID_LAST_CONTACT_AMY).build();
+        assertTrue(DESC_AMY.equals(editedDescriptor_lastcontact));
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -66,7 +66,8 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
                 + editPersonDescriptor.getAddress().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + ", upcoming="
-                + editPersonDescriptor.getUpcoming().orElse(null) + "}";
+                + editPersonDescriptor.getUpcoming().orElse(null) + ", lastcontact="
+                + editPersonDescriptor.getLastcontact().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -127,7 +127,7 @@ public class AddressBookParserTest {
         LastContactCommand command = (LastContactCommand) parser.parseCommand(
                 LastContactCommand.COMMAND_WORD + " "
                         + PREFIX_NAME + name + " "
-                        + PREFIX_LASTCONTACT + lastContact.getDateTimeString());
+                        + PREFIX_LASTCONTACT + lastContact);
         assertEquals(new LastContactCommand(name, lastContact), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+    import seedu.address.model.person.LastContact;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Upcoming;
@@ -28,6 +29,7 @@ public class ParserUtilTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_UPCOMING = "12-12-2024";
+    private static final String INVALID_LASTCONTACT = "12-12-2024";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -36,6 +38,7 @@ public class ParserUtilTest {
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
     private static final String VALID_UPCOMING = "12-12-2024 1200";
+    private static final String VALID_LASTCONTACT = "13-03-2024 0600";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -218,5 +221,28 @@ public class ParserUtilTest {
         String upcomingWithWhitespace = WHITESPACE + VALID_UPCOMING + WHITESPACE;
         Upcoming expectedUpcoming = new Upcoming(VALID_UPCOMING);
         assertEquals(expectedUpcoming, ParserUtil.parseUpcoming(upcomingWithWhitespace));
+    }
+
+    @Test
+    public void parseLastContact_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseLastContact(null));
+    }
+
+    @Test
+    public void parseLastContact_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseLastContact(INVALID_LASTCONTACT));
+    }
+
+    @Test
+    public void parseLastContact_validValueWithoutWhitespace_returnsLastContact() throws Exception {
+        LastContact expectedLastContact = new LastContact(VALID_LASTCONTACT);
+        assertEquals(expectedLastContact, ParserUtil.parseLastContact(VALID_LASTCONTACT));
+    }
+
+    @Test
+    public void parseLastContact_validValueWithWhitespace_returnsTrimmedLastContact() throws Exception {
+        String lastContactWithWhitespace = WHITESPACE + VALID_LASTCONTACT + WHITESPACE;
+        LastContact expectedLastContact = new LastContact(VALID_LASTCONTACT);
+        assertEquals(expectedLastContact, ParserUtil.parseLastContact(lastContactWithWhitespace));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
-    import seedu.address.model.person.LastContact;
+import seedu.address.model.person.LastContact;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Upcoming;

--- a/src/test/java/seedu/address/model/person/LastContactTest.java
+++ b/src/test/java/seedu/address/model/person/LastContactTest.java
@@ -24,7 +24,7 @@ class LastContactTest {
     void constructor_validDateTime_createsLastContact() {
         String validDateTime = "05-03-2024 0600";
         LastContact lastContact = new LastContact(validDateTime);
-        assertEquals(validDateTime, lastContact.getDateTimeString());
+        assertEquals(validDateTime, lastContact.toString());
     }
 
     @Test
@@ -42,7 +42,7 @@ class LastContactTest {
     void getDateTimeString() {
         String validDateTime = "05-03-2024 0600";
         LastContact lastContact = new LastContact(validDateTime);
-        assertEquals(validDateTime, lastContact.getDateTimeString());
+        assertEquals(validDateTime, lastContact.toString());
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -63,6 +63,8 @@ public class PersonUtil {
         }
         descriptor.getUpcoming()
                 .ifPresent(upcoming -> sb.append(PREFIX_UPCOMING).append(upcoming.toString()).append(" "));
+        descriptor.getLastcontact().ifPresent(lastContact -> sb.append(PREFIX_LASTCONTACT).append(" ")
+                .append(lastContact.getDateTimeString()));
         return sb.toString();
     }
 }

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -39,7 +39,7 @@ public class PersonUtil {
         person.getTags().stream().forEach(
                 s -> sb.append(PREFIX_TAG + s.tagName + " "));
         sb.append(PREFIX_UPCOMING + person.getUpcoming().toString() + " ");
-        sb.append(PREFIX_LASTCONTACT + person.getLastcontact().getDateTimeString() + " ");
+        sb.append(PREFIX_LASTCONTACT + person.getLastcontact().toString() + " ");
         return sb.toString();
     }
 
@@ -62,9 +62,10 @@ public class PersonUtil {
             }
         }
         descriptor.getUpcoming()
-                .ifPresent(upcoming -> sb.append(PREFIX_UPCOMING).append(upcoming.toString()).append(" "));
-        descriptor.getLastcontact().ifPresent(lastContact -> sb.append(PREFIX_LASTCONTACT).append(" ")
-                .append(lastContact.getDateTimeString()));
+                .ifPresent(upcoming -> sb.append(PREFIX_UPCOMING).append(upcoming).append(" "));
+        descriptor.getLastcontact()
+                .ifPresent(lastContact -> sb.append(PREFIX_LASTCONTACT)
+                        .append(lastContact).append(" "));
         return sb.toString();
     }
 }


### PR DESCRIPTION
Now edit command should be able to edit lastcontact field which was not allowed in previous version.

To edit the lastcontact field, you can do this for example:
edit 1 lc/18-03-2024 1947

This will edit the first index last contact field to 18-03-2024 1947