### PR TITLE
Bug fix last contact not filtering properly

### DIFF
--- a/src/main/java/seedu/address/logic/commands/LastContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LastContactCommand.java
@@ -49,6 +49,7 @@ public class LastContactCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        model.sortFilteredPersonList(null); // Resetting the sort order
         model.updateFilteredPersonList(HAS_LAST_CONTACTED_PREDICATE);
         model.sortFilteredPersonList(SORT_COMPARATOR);
 


### PR DESCRIPTION
After entering `upcoming`, `lastcontact` command was not filtering and sorting per normal.

Add new line to reset the ordering first to get back original list, then do the sorting from the original list instead.