### PR TITLE
Yunchao/upcoming future date only

### DIFF
--- a/src/main/java/seedu/address/model/person/LastContact.java
+++ b/src/main/java/seedu/address/model/person/LastContact.java
@@ -52,7 +52,7 @@ public class LastContact implements Comparable<LastContact> {
         String trimmedDateTime = dateTime.trim();
         try {
             LocalDateTime parsedDateTime = LocalDateTime.parse(trimmedDateTime, DATETIME_FORMATTER);
-            return !parsedDateTime.isAfter(LocalDateTime.now()); // Successfully parsed, input matches the format
+            return parsedDateTime.isBefore(LocalDateTime.now()); // Successfully parsed, input matches the format
         } catch (DateTimeParseException e) {
             return false; // Parsing failed, input does not match the format
         }

--- a/src/main/java/seedu/address/model/person/Upcoming.java
+++ b/src/main/java/seedu/address/model/person/Upcoming.java
@@ -60,8 +60,8 @@ public class Upcoming implements Comparable<Upcoming> {
             return true;
         }
         try {
-            LocalDateTime.parse(dateTimeStr, DATETIME_FORMATTER);
-            return true;
+            LocalDateTime parsedDateTime = LocalDateTime.parse(dateTimeStr, DATETIME_FORMATTER);
+            return parsedDateTime.isAfter(LocalDateTime.now());
         } catch (DateTimeParseException e) {
             return false;
         }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -24,22 +24,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"), new Upcoming("23-08-2024 1500"), DUMMY_LASTCONTACT),
+                getTagSet("friends"), new Upcoming("23-08-2025 1500"), DUMMY_LASTCONTACT),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends"), new Upcoming("08-08-2024 1515"), DUMMY_LASTCONTACT),
+                getTagSet("colleagues", "friends"), new Upcoming("08-08-2025 1515"), DUMMY_LASTCONTACT),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours"), new Upcoming("03-03-2024 0930"), DUMMY_LASTCONTACT),
+                getTagSet("neighbours"), new Upcoming("03-03-2025 0930"), DUMMY_LASTCONTACT),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family"), new Upcoming("01-01-2024 1200"), DUMMY_LASTCONTACT),
+                getTagSet("family"), new Upcoming("01-01-2025 1200"), DUMMY_LASTCONTACT),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates"), new Upcoming("12-12-2023 1800"), DUMMY_LASTCONTACT),
+                getTagSet("classmates"), new Upcoming("12-12-2025 1800"), DUMMY_LASTCONTACT),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"), new Upcoming("25-12-2023 2000"), DUMMY_LASTCONTACT)
+                getTagSet("colleagues"), new Upcoming("25-12-2025 2000"), DUMMY_LASTCONTACT)
         };
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -160,7 +160,7 @@ public class PersonTest {
         assertNotEquals(ALICE.hashCode(), editedAlice.hashCode());
 
         // different upcoming -> different hash code
-        editedAlice = new PersonBuilder(ALICE).withUpcoming("01-01-2024 1200").build();
+        editedAlice = new PersonBuilder(ALICE).withUpcoming("01-01-2025 1200").build();
         assertNotEquals(ALICE.hashCode(), editedAlice.hashCode());
 
         // different lastcontact -> same hash code (lastcontact not included in hashCode)

--- a/src/test/java/seedu/address/model/person/UpcomingTest.java
+++ b/src/test/java/seedu/address/model/person/UpcomingTest.java
@@ -13,10 +13,10 @@ public class UpcomingTest {
     @Test
     public void constructor_validDateTimeString_success() {
         // Valid date and time string
-        Upcoming upcoming = new Upcoming("01-01-2022 1200");
-        assertTrue(Upcoming.isValidUpcoming("01-01-2022 1200"));
+        Upcoming upcoming = new Upcoming("01-01-2025 1200");
+        assertTrue(Upcoming.isValidUpcoming("01-01-2025 1200"));
         assertTrue(Upcoming.isValidUpcoming("")); // Empty string is considered valid
-        assertEquals("01-01-2022 1200", upcoming.toString());
+        assertEquals("01-01-2025 1200", upcoming.toString());
     }
 
     @Test
@@ -28,31 +28,31 @@ public class UpcomingTest {
 
     @Test
     public void compareTo_sameDateTime_returnsZero() {
-        Upcoming upcoming1 = new Upcoming("01-04-2023 1500");
-        Upcoming upcoming2 = new Upcoming("01-04-2023 1500");
+        Upcoming upcoming1 = new Upcoming("01-04-2025 1500");
+        Upcoming upcoming2 = new Upcoming("01-04-2025 1500");
 
         assertEquals(0, upcoming1.compareTo(upcoming2));
     }
 
     @Test
     public void compareTo_laterDateTime_returnsPositive() {
-        Upcoming upcoming1 = new Upcoming("01-04-2023 1500");
-        Upcoming upcoming2 = new Upcoming("01-04-2023 1400");
+        Upcoming upcoming1 = new Upcoming("01-04-2025 1500");
+        Upcoming upcoming2 = new Upcoming("01-04-2025 1400");
 
         assertTrue(upcoming1.compareTo(upcoming2) > 0);
     }
 
     @Test
     public void compareTo_earlierDateTime_returnsNegative() {
-        Upcoming upcoming1 = new Upcoming("01-04-2023 1400");
-        Upcoming upcoming2 = new Upcoming("01-04-2023 1500");
+        Upcoming upcoming1 = new Upcoming("01-04-2025 1400");
+        Upcoming upcoming2 = new Upcoming("01-04-2025 1500");
 
         assertTrue(upcoming1.compareTo(upcoming2) < 0);
     }
 
     @Test
     public void compareTo_nullUpcoming_throws() {
-        Upcoming upcoming1 = new Upcoming("01-04-2023 1500");
+        Upcoming upcoming1 = new Upcoming("01-04-2025 1500");
         Upcoming upcoming2 = new Upcoming("");
 
         // Assuming you want to throw an exception when comparing with a null Upcoming
@@ -67,8 +67,8 @@ public class UpcomingTest {
 
     @Test
     public void compareTo_differentDayMonthYear_returnsCorrectValue() {
-        Upcoming upcoming1 = new Upcoming("01-04-2023 1500");
-        Upcoming upcoming2 = new Upcoming("02-05-2024 1600");
+        Upcoming upcoming1 = new Upcoming("01-04-2025 1500");
+        Upcoming upcoming2 = new Upcoming("02-05-2026 1600");
 
         assertTrue(upcoming1.compareTo(upcoming2) < 0);
         assertTrue(upcoming2.compareTo(upcoming1) > 0);
@@ -76,47 +76,47 @@ public class UpcomingTest {
 
     @Test
     public void equals_sameObject_returnsTrue() {
-        Upcoming upcoming = new Upcoming("01-01-2022 1200");
+        Upcoming upcoming = new Upcoming("01-01-2025 1200");
         assertTrue(upcoming.equals(upcoming));
     }
 
     @Test
     public void equals_nullObject_returnsFalse() {
-        Upcoming upcoming = new Upcoming("01-01-2022 1200");
+        Upcoming upcoming = new Upcoming("01-01-2025 1200");
         assertFalse(upcoming.equals(null));
     }
 
     @Test
     public void equals_differentClass_returnsFalse() {
-        Upcoming upcoming = new Upcoming("01-01-2022 1200");
-        assertFalse(upcoming.equals("01-01-2022 1200"));
+        Upcoming upcoming = new Upcoming("01-01-2025 1200");
+        assertFalse(upcoming.equals("01-01-2025 1200"));
     }
 
     @Test
     public void equals_sameDateTime_returnsTrue() {
-        Upcoming upcoming1 = new Upcoming("01-01-2022 1200");
-        Upcoming upcoming2 = new Upcoming("01-01-2022 1200");
+        Upcoming upcoming1 = new Upcoming("01-01-2025 1200");
+        Upcoming upcoming2 = new Upcoming("01-01-2025 1200");
         assertTrue(upcoming1.equals(upcoming2));
     }
 
     @Test
     public void equals_differentDateTime_returnsFalse() {
-        Upcoming upcoming1 = new Upcoming("01-01-2022 1200");
-        Upcoming upcoming2 = new Upcoming("02-01-2022 1200");
+        Upcoming upcoming1 = new Upcoming("01-01-2025 1200");
+        Upcoming upcoming2 = new Upcoming("02-01-2025 1200");
         assertFalse(upcoming1.equals(upcoming2));
     }
 
     @Test
     public void equals_differentUpcomingStatus_returnsFalse() {
         Upcoming upcoming1 = new Upcoming("");
-        Upcoming upcoming2 = new Upcoming("01-04-2023 1500");
+        Upcoming upcoming2 = new Upcoming("01-04-2025 1500");
         assertFalse(upcoming1.equals(upcoming2));
     }
 
     @Test
     public void equals_oneUpcomingEmpty_returnsFalse() {
         Upcoming upcoming1 = new Upcoming("");
-        Upcoming upcoming2 = new Upcoming("01-04-2023 1500");
+        Upcoming upcoming2 = new Upcoming("01-04-2025 1500");
         assertFalse(upcoming1.equals(upcoming2));
     }
 
@@ -129,22 +129,22 @@ public class UpcomingTest {
 
     @Test
     public void hashCode_sameDateTime_returnsSameHashCode() {
-        Upcoming upcoming1 = new Upcoming("01-01-2022 1200");
-        Upcoming upcoming2 = new Upcoming("01-01-2022 1200");
+        Upcoming upcoming1 = new Upcoming("01-01-2025 1200");
+        Upcoming upcoming2 = new Upcoming("01-01-2025 1200");
         assertEquals(upcoming1.hashCode(), upcoming2.hashCode());
     }
 
     @Test
     public void hashCode_differentDateTime_returnsDifferentHashCode() {
-        Upcoming upcoming1 = new Upcoming("01-01-2022 1200");
-        Upcoming upcoming2 = new Upcoming("02-01-2022 1200");
+        Upcoming upcoming1 = new Upcoming("01-01-2025 1200");
+        Upcoming upcoming2 = new Upcoming("02-01-2025 1200");
         assertNotEquals(upcoming1.hashCode(), upcoming2.hashCode());
     }
 
     @Test
     public void toString_hasUpcoming_returnsFormattedDateTime() {
-        Upcoming upcoming = new Upcoming("01-01-2022 1200");
-        String expected = "01-01-2022 1200";
+        Upcoming upcoming = new Upcoming("01-01-2025 1200");
+        String expected = "01-01-2025 1200";
         assertEquals(expected, upcoming.toString());
     }
 
@@ -157,7 +157,7 @@ public class UpcomingTest {
 
     @Test
     public void hasUpcoming_true() {
-        Upcoming upcoming = new Upcoming("01-01-2022 1200");
+        Upcoming upcoming = new Upcoming("01-01-2025 1200");
         assertTrue(upcoming.hasUpcoming());
     }
 


### PR DESCRIPTION
fixes #74 
- Added additional check for dates to be after now() before being initiated as an Upcoming
- Edited `LastContact.java` to use isBefore instead of !isAfter
- Updated dummy test data 