### PR TITLE
Enable the fields in the Profile Panel to wrap if it is too long

### DIFF
--- a/src/main/resources/view/PersonProfile.fxml
+++ b/src/main/resources/view/PersonProfile.fxml
@@ -10,12 +10,12 @@
 
 <VBox id="profilePane" fx:id="profilePane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane>
-    <VBox alignment="CENTER_LEFT" minHeight="225" GridPane.rowIndex="0">
+    <VBox alignment="CENTER_LEFT" minHeight="225" maxWidth="375" GridPane.rowIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <VBox spacing="5" alignment="CENTER">
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" text="\$first" styleClass="cell_big_label" wrapText="true"/>
         <ImageView>
           <image>
             <Image url="@/images/profile.jpg" />
@@ -26,19 +26,19 @@
       </VBox>
     </VBox>
 
-    <VBox alignment="CENTER_LEFT" minHeight="100" GridPane.rowIndex="1">
+    <VBox alignment="CENTER_LEFT" minHeight="100" maxWidth="375" GridPane.rowIndex="1">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>
       <Label text="Contact Information" styleClass="cell_big_label" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-      <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" wrapText="true"/>
+      <Label fx:id="address" styleClass="cell_small_label" text="\$address" wrapText="true"/>
+      <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>
       <Label fx:id="upcoming" styleClass="cell_small_label" text="\$upcoming" />
-      <Label fx:id="lastcontact" styleClass="cell_small_label" text="\$lastcontacted"/>
+      <Label fx:id="lastcontact" styleClass="cell_small_label" text="\$lastcontacted" />
     </VBox>
 
-    <VBox alignment="CENTER_LEFT" minHeight="100" GridPane.rowIndex="2">
+    <VBox alignment="CENTER_LEFT" minHeight="100" maxWidth="300" GridPane.rowIndex="2">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>


### PR DESCRIPTION
The Profile Panel is cutting off very long but valid names and address and there is no other way to view them, even after resizing the window.

Let's enable the set the max width of the VBox within the Profile Panel and enable to fields within to wrap around.

Setting the max width smaller than the min width of the Profile Panel and enabling wrapping for the labels will ensure that the fields will not be cut off and be visible at least in some window size.