### PR TITLE
Fix hard app crash bug when editing field thru json

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -128,6 +128,9 @@ class JsonAdaptedPerson {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
                     LastContact.class.getSimpleName()));
         }
+        if (!LastContact.isValidDateTime(lastcontact)) {
+            throw new IllegalValueException(LastContact.MESSAGE_CONSTRAINTS);
+        }
         final LastContact modelLastContact = new LastContact(lastcontact);
 
         return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelUpcoming, modelLastContact);

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -139,7 +139,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
                 VALID_TAGS, VALID_UPCOMING, INVALID_LASTCONTACT);
         String expectedMessage = String.format(LastContact.MESSAGE_CONSTRAINTS, INVALID_LASTCONTACT);
-        assertThrows(IllegalArgumentException.class, expectedMessage, person::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test


### PR DESCRIPTION
fixes #146 

## Bug TLDR: 
when JSON is edited to invalid dateTime for LC field, app hard crashes and refuses to open

expected behavior: app crashes gracefully by dumping old JSON and starting from blank slate

## Reason for crash:
- LC field being null was not explicitly checked from in `JsonAdapterPerson.java`
- when LC or U field is read from JSON, it must be explicitly checked for validity before calling constructor in `JsonAdapterPerson.java`
- isValidDateTime check was not called for LC field causing a full crash